### PR TITLE
Prevent Space to create invalid urns and complete with encode options

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,8 +65,8 @@ functionality.
 
 ```typescript
 const mongoIds = new URNSpace("mongoId");
-const record1: BaseURN<"mongoId", string> = mongoIds("1569-ab32-9f7a-15b3-9ccd"); // OK
-const record2: string = mongoIds("1569-ab32-9f7a-15b3-9ccd"); // Also fine, but loses type information
+const record1: BaseURN<"mongoId", string> = mongoIds.urn("1569-ab32-9f7a-15b3-9ccd"); // OK
+const record2: string = mongoIds.urn("1569-ab32-9f7a-15b3-9ccd"); // Also fine, but loses type information
 const record3: BaseURN<"mongoId", string> = "urn:mongoId:1569-ab32-9f7a-15b3-9ccd"; // works too
 const record4: BaseURN<"mongoId", string> = "urn:postgres:1569-ab32-9f7a-15b3-9ccd"; // Nope
 const record5: BaseURN<"mongoId", string> = "1569-ab32-9f7a-15b3-9ccd"; // Also nope
@@ -77,7 +77,7 @@ This also allows casting, _e.g._,
 ```typescript
 // This narrows the type of `record3` from string to a more specific URN syntax string
 if (mongoIds.is(record3)) {
-  const id = nss(record3); // Extract the embedded hex id
+  const id = mongoIds.nss(record3); // Extract the embedded hex id
 }
 ```
 

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "main": "lib/index.js",
   "scripts": {
     "build": "tsc",
+    "prepare": "npm run build",
     "test": "jest"
   },
   "files": [

--- a/src/space.spec.ts
+++ b/src/space.spec.ts
@@ -52,6 +52,26 @@ describe("Test usage of urnSpace", () => {
       "Assumption that 'urn:example:d' belongs to the specified URNSpace('example') is faulty"
     );
   });
+  it("should not create invalid urns with an NSS constraint", () => {
+    /**
+     * In this case, return type of the `pred` function provides an additional
+     * constraint on the potential values for the NSS in this space.  This is
+     * picked up by TypeScripts type analysis (and, thus, allows us to detect
+     * deviations from that type in string literals).
+     **/
+    const space = new URNSpace("example", {
+      pred: (s: string): s is "a" | "b" => s === "a" || s === "b",
+    });
+
+    expect(space.is("urn:example:b")).toEqual(true);
+    expect(space.is("urn:example:c")).toEqual(false);
+    expect(() => space.urn("d")).toThrow(
+      "Assumption that 'urn:example:d' belongs to the specified URNSpace('example') is faulty"
+    );
+    expect(() => space.assume("urn:example:d")).toThrow(
+      "Assumption that 'urn:example:d' belongs to the specified URNSpace('example') is faulty"
+    );
+  });
   it("should create a space with a decoder", () => {
     /** Now we create a URNSpace with a transform function. */
     const space = new URNSpace("example", {

--- a/src/space.spec.ts
+++ b/src/space.spec.ts
@@ -26,6 +26,15 @@ describe("Test usage of urnSpace", () => {
     /** Create a URN by hand that is no part of this URN space and ensure it fails the `is` test */
     expect(space.is("urn:other:a")).toEqual(false);
   });
+  it("should create a space with encoder if provided", () => {
+    const space = new URNSpace("example", {
+      // encode to v^2
+      encode: (v: number): string => {
+        return (v * v).toString()
+      }
+    })
+    expect(space.urn(2)).toEqual('urn:example:4')
+  })
   it("should create a space with an NSS constraint", () => {
     /**
      * In this case, return type of the `pred` function provides an additional

--- a/src/space.ts
+++ b/src/space.ts
@@ -30,8 +30,11 @@ export class URNSpace<NID extends string, NSS extends string, R> {
    * This allows you to deliberately create URNs that are part of a
    * more narrow subspace.
    */
-  urn<N extends NSS>(nss: N, decode?: (nss: string) => R): BaseURN<NID, N> {
-    return createURN(this.nid, nss);
+  urn<N extends NSS>(nss: N | R): BaseURN<NID, N> {
+    if (this.options?.encode) {
+      return createURN(this.nid, this.options.encode(nss as R) as N);
+    }
+    return createURN(this.nid, nss as N);
   }
   /**
    * This is the main benefit of a `URNSpace`, it allows you to perform a runtime
@@ -92,7 +95,7 @@ export class URNSpace<NID extends string, NSS extends string, R> {
         try {
           this.options.decode(parsed.nss);
         } catch (e) {
-          throw new Error(`Assumption that '${s}' belongs to the specified URNSpace('${this.nid}') fails in decoding: ${e.message}`);
+          throw new Error(`Assumption that '${s}' belongs to the specified URNSpace('${this.nid}') fails in decoding: ${(e as Error).message}`);
         }
       }
       /** If we get here, the NSS has passed all further validation we can do. */
@@ -137,6 +140,7 @@ export class URNSpace<NID extends string, NSS extends string, R> {
  */
 export interface SpaceOptions<NSS extends string, R> {
   pred: (nss: string) => nss is NSS;
+  encode: (val: R) => string;
   decode: (nss: string) => R;
 }
 

--- a/src/space.ts
+++ b/src/space.ts
@@ -31,10 +31,18 @@ export class URNSpace<NID extends string, NSS extends string, R> {
    * more narrow subspace.
    */
   urn<N extends NSS>(nss: N | R): BaseURN<NID, N> {
+    let createdURN: BaseURN<NID, N>;
     if (this.options?.encode) {
-      return createURN(this.nid, this.options.encode(nss as R) as N);
+      createdURN = createURN(this.nid, this.options.encode(nss as R) as N);
+    } else {
+      createdURN = createURN(this.nid, nss as N);
     }
-    return createURN(this.nid, nss as N);
+    try {
+      this.assume(createdURN);
+      return createdURN;
+    } catch (e) {
+      throw e;
+    }
   }
   /**
    * This is the main benefit of a `URNSpace`, it allows you to perform a runtime


### PR DESCRIPTION
Thanks for creating this fantastic library!

I found two important features with `URNSpace` missing when I was using it. I thought I share in case you think they make sense.

1. currently `space.urn` will happily create invalid urns when `pred` option is specified (see test)
2. I found an `encode` option in addition to the `decode` useful. (see use case below + test)

#### Use Case for encode

I have urns that take other urns, e.g. `urn:example:edge:(urn:example:node:a, urn:example:node:b)`

The `decode` option helps a lot to parse urns like this, but creating those urns is very cumbersome. Adding an `encode` option would make this very natural. Thoughts?